### PR TITLE
Copy all things into container

### DIFF
--- a/DOCKERFILE
+++ b/DOCKERFILE
@@ -1,20 +1,31 @@
 FROM hackoregoncivic/backend-docker-django
-MAINTAINER Brian H. Grant <brian@hackoregon.org> & "M. Edward (Ed) Borasky <ed.borasky@hackoregon.org>
+MAINTAINER Brian H. Grant <brian@hackoregon.org> & M. Edward (Ed) Borasky <ed.borasky@hackoregon.org>
 ENV PYTHONUNBUFFERED 1
 ARG DEBUG=false
 
 WORKDIR /code
 
+# Put all requirements files in the workdir
 COPY /requirements/* /code/
+
+# Copy the django apps to be installed locally via pip
 COPY hackoregon_examplar /code/hackoregon_examplar
+
 RUN ls
 RUN if [ "$DEBUG" = true  ] ; then pip install -r development.txt ; else pip install -r production.txt ; fi
 
 RUN python
 
+# src_files is home to all the django files that "wrap" the django apps installed by pip
 RUN mkdir src_files
 
+# Copy all scripts and make sure they are executable
 COPY bin /code/src_files/bin/
 RUN chmod +x *.py
+
+# Copy settings and staticfiles to make sure they are baked into the container
+# rather than always expecting them to be mounted at runtime.
+COPY local_settings /code/src_files/local_settings
+COPY staticfiles /code/src_files/staticfiles
 
 ENTRYPOINT [ "/code/src_files/bin/docker-entrypoint.sh" ]

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -6,7 +6,6 @@
 # http://linuxcommand.org/lc3_man_pages/seth.html:
 # -e  Exit immediately if a command exits with a non-zero status.
 set -e
-echo "hi i am a container"
 
 # Pull in environment variables values from AWS Parameter Store, and preserve the exports
 # source usage per https://stackoverflow.com/q/14742358/452120 (iff running on travis-ci)

--- a/hackoregon_examplar/api/__init__.py
+++ b/hackoregon_examplar/api/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'hackoregon_examplar.api.apps.ApiConfig'


### PR DESCRIPTION
Since the volume mount defined in docker-compose.yml isn't used when running the container in production, the relevant files need to be copied at build time.

The `hackoregon_examplar` package is already being copied and installed and this works correctly even without the volume mount. 

The actual culprit was the lack of `local_settings`, which of course declares `api` among other things as an installed app. 